### PR TITLE
Addressing multiple small bugs

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -113,6 +113,9 @@ def main():
     groups_df = load_groups(args.groups, args.pats)
 
     # calc homog tables:
+    if args.rlen < 2:
+        eprint('Error: --rlen / -l is required for build (minimal CpGs per read, e.g. -l 4)')
+        exit(1)
     uxm_dict = gen_homogs(df, groups_df['full_path'], args.tmp_dir,
                           args.verbose, args.rlen, args.force,
                           args.nodump, args.debug, args.threads)

--- a/src/plot.py
+++ b/src/plot.py
@@ -57,7 +57,7 @@ class PlotDeconv:
             return
         others = self.df[self.df < self.min_rate].sum()
         self.df[self.df < self.min_rate] = 0.0
-        self.df = self.df.append(others.rename('other'))
+        self.df = pd.concat([self.df, others.rename('other').to_frame().T])
 
     def gen_bars_colors_hatches(self, nr_tissues):
         """


### PR DESCRIPTION
***Commit [3b32227](https://github.com/nloyfer/UXM_deconv/pull/25/commits/3b3222737a4f13dd013abf6cc910143029a85042):***

Replaced defunct 'pandas.DataFrame.append()' method. This method no long exists in pandas versions compatible with python≥3 (which the README states is necessary for the UXM tool). 

***Commit [7ce7d73](https://github.com/nloyfer/UXM_deconv/pull/25/commits/7ce7d735c05c38b09f246458c137075fa37c2043):***

`rlen` is not a required argument of `uxm build` and it is stated that "`By default this value is deduced from the atlas name`". However, this is not the case. The `deduce_l_from_name()` function is not called in `build` (and wouldn't work in `build` anyway as it uses `args.atlas` of which `build` has no equivalent parameter). When `rlen` isn't explicitly passed to `build`, the default (-1) is propogated into directory creation for memoization files. Therefore, a dir is created named `l-1` which then breaks downstream `wgbstools homog` function calls. This commit simply adds an explicit check in `build::main()` that ensures `rlen` is passed. More elegant solutions would be possible here, but would require a new/adjusted `deduce_l_from_name()` function